### PR TITLE
Sensorview file output change.

### DIFF
--- a/resources/openccsensors/resources/lua/sensorview
+++ b/resources/openccsensors/resources/lua/sensorview
@@ -173,7 +173,7 @@ while true do
 		if p1 == "s" then
 			--save sensor detailed output.
 			if detailLines then
-				local fileHandle = io.open("sensorDetailed-"..sideNames[sideSelection], "w")
+				local fileHandle = io.open("sensorDetailed-"..sideNames[sideSelection].."-"..targetNameMenuTable[targetSelection], "w")
 				if fileHandle then
 					for k, v in ipairs(detailLines) do
 						fileHandle:write(v.."\n")


### PR DESCRIPTION
Updated sensorview's file output target (S-key to use) to use the format sensorDetailed-<side>-<target> rather than sensorDetailed-<side> to make external comparison of data from multiple targets on a single sensor more feasible.
