### PR TITLE
Add IPowerReceptor handler

### DIFF
--- a/src/openccsensors/common/sensors/buildcraft/BuildCraftSensorInterface.java
+++ b/src/openccsensors/common/sensors/buildcraft/BuildCraftSensorInterface.java
@@ -2,6 +2,7 @@ package openccsensors.common.sensors.buildcraft;
 
 import java.util.Map;
 
+import buildcraft.api.power.IPowerReceptor;
 import buildcraft.energy.IEngineProvider;
 
 import cpw.mods.fml.common.registry.GameRegistry;
@@ -30,6 +31,16 @@ public class BuildCraftSensorInterface implements ISensorInterface {
 				if (entity instanceof IEngineProvider)
 				{
 					return new EngineTarget((TileEntity) entity);
+				}
+				return null;
+			}
+		});
+		retriever.registerTarget(new ITargetWrapper() {
+			@Override
+			public ISensorTarget createNew(Object entity, int sx, int sy, int sz) {
+				if (entity instanceof IPowerReceptor && !(entity instanceof IEngineProvider))
+				{
+					return new PowerReceptorTarget((TileEntity) entity);
 				}
 				return null;
 			}

--- a/src/openccsensors/common/sensors/buildcraft/PowerReceptorTarget.java
+++ b/src/openccsensors/common/sensors/buildcraft/PowerReceptorTarget.java
@@ -1,0 +1,38 @@
+package openccsensors.common.sensors.buildcraft;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import buildcraft.api.power.IPowerReceptor;
+import buildcraft.energy.IEngineProvider;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import openccsensors.common.api.ISensorTarget;
+import openccsensors.common.sensors.TileSensorTarget;
+
+public class PowerReceptorTarget extends TileSensorTarget implements ISensorTarget {
+
+	PowerReceptorTarget(TileEntity targetEntity) {
+		super(targetEntity);
+	}
+
+	@Override
+	public Map getDetailInformation(World world) {
+		
+		HashMap retMap = new HashMap();
+
+		IPowerReceptor tileReceptor = (IPowerReceptor) world
+				.getBlockTileEntity(xCoord, yCoord, zCoord);
+
+		retMap.put("Latency", tileReceptor.getPowerProvider().getLatency());
+		retMap.put("MinReceived", tileReceptor.getPowerProvider().getMinEnergyReceived());
+		retMap.put("MaxReceived", tileReceptor.getPowerProvider().getMaxEnergyReceived());
+		retMap.put("Activation", tileReceptor.getPowerProvider().getActivationEnergy());
+		retMap.put("MaxStored", tileReceptor.getPowerProvider().getMaxEnergyStored());
+		retMap.put("Stored", tileReceptor.getPowerProvider().getEnergyStored());
+
+		return retMap;
+	}
+
+}


### PR DESCRIPTION
Adds a handler in the buildcraft sensor that handled IPowerReceptors (engines are IPowerReceptors so the addition excludes them). Untested, but should work.
