### PR TITLE
Change to error return methodology.

### DIFF
--- a/resources/openccsensors/resources/lua/apis/sensor
+++ b/resources/openccsensors/resources/lua/apis/sensor
@@ -2,11 +2,11 @@ local function waitForResponse( _id )
 	while true do
 		local event = {os.pullEvent()}
 		if event[2] == _id then
-		  if event[1] == "ocs_success" then
-			return event[3]
-		  elseif event[1] == "ocs_error" then
-		    error(event[3],2)
-		  end
+			if event[1] == "ocs_success" then
+				return event[3]
+			elseif event[1] == "ocs_error" then
+				return nil, event[3]
+			end
 		end
 	end
 end


### PR DESCRIPTION
This minor change would swap out the error() call to a `return nil, errormessage`, to better allow error handling in calling programs.  It is a regular occurrence to have, for instance, proximity sensor targets suddenly leave the range of the sensor, and it is unwise for this to cause program-terminating errors when this behavior is not expected.

This pull request includes four cruft commits due to Mikee manually adding my updated images in previously, so I cannot exclude them for some reason (or cannot find the option in github).  The Files Changed tab correctly reflects the extent of the actual changes.

Please note that this commit also corrects the surrounding whitespace to use the standard single-tab-per-level indentation scheme that the entirety of the Lua code in the rest of the mod uses.
