### PR TITLE
Create a OpenCCSensors-specific Creative tab

### DIFF
--- a/mods/openccsensors/languages/en_US.lang
+++ b/mods/openccsensors/languages/en_US.lang
@@ -19,3 +19,5 @@ item.openccsensors.advancedAmplifier.name=Advanced Amplifier
 
 gui.openccsensors.sensor=Sensor
 turtle.openccsensors.sensor.adjective=Sensor
+
+itemGroup.tabOpenCCSensors=OpenCCSensors 

--- a/src/openccsensors/OpenCCSensors.java
+++ b/src/openccsensors/OpenCCSensors.java
@@ -28,7 +28,8 @@ import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkMod;
-
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.ItemStack;
 
 @Mod( modid = "OCS", name = "OpenCCSensors", version = "0.1.5", dependencies = "required-after:ComputerCraft;after:CCTurtle;after:BuildCraft|Core;after:IC2;after:Thaumcraft;after:AppliedEnergistics")
 @NetworkMod(clientSideRequired = true, serverSideRequired = false)
@@ -89,6 +90,12 @@ public class OpenCCSensors {
 	public static String LANGUAGE_PATH;
 	public static String LUA_PATH;
 	public static String TEXTURE_PATH;
+
+	public static CreativeTabs tabOpenCCSensors = new CreativeTabs("tabOpenCCSensors") {
+                public ItemStack getIconItemStack() {
+                        return new ItemStack(Blocks.sensorBlock, 1, 0);
+                }
+  };
 
 	@Instance( value = "OCS" )
 	public static OpenCCSensors instance;

--- a/src/openccsensors/common/block/BlockGauge.java
+++ b/src/openccsensors/common/block/BlockGauge.java
@@ -27,7 +27,7 @@ public class BlockGauge extends BlockContainer {
 	public BlockGauge() {
 		super(OpenCCSensors.Config.gaugeBlockID, Material.ground);
 		setHardness(0.5F);
-		setCreativeTab(ComputerCraftAPI.getCreativeTab());
+		setCreativeTab(OpenCCSensors.tabOpenCCSensors);
 		GameRegistry.registerBlock(this, "gauge");
 		GameRegistry.registerTileEntity(TileEntityGauge.class, "gauge");
 		setUnlocalizedName("openccsensors.gauge");

--- a/src/openccsensors/common/block/BlockSensor.java
+++ b/src/openccsensors/common/block/BlockSensor.java
@@ -29,7 +29,7 @@ public class BlockSensor extends BlockContainer {
 		
 		super(OpenCCSensors.Config.sensorBlockID, Material.ground);
 		setHardness(0.5F);
-		setCreativeTab(ComputerCraftAPI.getCreativeTab());
+		setCreativeTab(OpenCCSensors.tabOpenCCSensors);
 		GameRegistry.registerBlock(this, "sensor");
 		GameRegistry.registerTileEntity(TileEntitySensor.class, "sensor");
 		setUnlocalizedName("openccsensors.sensor");

--- a/src/openccsensors/common/item/ItemGeneric.java
+++ b/src/openccsensors/common/item/ItemGeneric.java
@@ -25,7 +25,7 @@ public class ItemGeneric extends Item {
 		setHasSubtypes(true);
 		setMaxDamage(0);
 		setMaxStackSize(64);
-		setCreativeTab(ComputerCraftAPI.getCreativeTab());
+		setCreativeTab(OpenCCSensors.tabOpenCCSensors);
 	}
 	
 	@Override

--- a/src/openccsensors/common/item/ItemSensorCard.java
+++ b/src/openccsensors/common/item/ItemSensorCard.java
@@ -36,7 +36,7 @@ public class ItemSensorCard extends Item implements ISensorCardRegistry {
 		super(OpenCCSensors.Config.sensorCardID);
 		setMaxDamage(0);
 		setHasSubtypes(true);
-		setCreativeTab(ComputerCraftAPI.getCreativeTab());
+		setCreativeTab(OpenCCSensors.tabOpenCCSensors);
 	}
 	
 	@Override


### PR DESCRIPTION
ComputerCraft 1.53(pr1) doesn't allow mods to add items to the ComputerCraft tab in the creative inventory anymore, so this patch moves all the OpenCCSensors items to their own new tab. 
