### PR TITLE
Fix compile errors, reduce imports

### DIFF
--- a/src/openccsensors/OpenCCSensors.java
+++ b/src/openccsensors/OpenCCSensors.java
@@ -1,5 +1,7 @@
 package openccsensors;
 
+import net.minecraft.creativetab.CreativeTabs;
+import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.Configuration;
 import net.minecraftforge.common.Property;
 import openccsensors.api.IItemMeta;
@@ -27,14 +29,12 @@ import openccsensors.common.turtle.TurtleUpgradeSensor;
 import openccsensors.common.util.OCSLog;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.Mod;
-import cpw.mods.fml.common.ModContainer;
+import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
 import cpw.mods.fml.common.SidedProxy;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.network.NetworkMod;
-import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.item.ItemStack;
 
 @Mod( modid = "OCS", name = "OpenCCSensors", version = "1.6.4.2", dependencies = "required-after:ComputerCraft;after:CCTurtle;after:BuildCraft|Core;after:IC2;after:Thaumcraft;after:AppliedEnergistics;after:RailCraft;after:ArsMagica;after:UniversalElectricity;after:ThermalExpansion")
 @NetworkMod(clientSideRequired = true, serverSideRequired = false)
@@ -116,7 +116,7 @@ public class OpenCCSensors {
 	@SidedProxy( clientSide = "openccsensors.client.ClientProxy", serverSide = "openccsensors.common.CommonProxy" )
 	public static CommonProxy proxy;
 	
-	@Mod.Init
+	@EventHandler
 	public void init( FMLInitializationEvent evt )
 	{
 		OCSLog.init();
@@ -128,7 +128,7 @@ public class OpenCCSensors {
 		proxy.registerRenderInformation();
 	}
 	
-	@Mod.PreInit
+	@EventHandler
 	public void preInit( FMLPreInitializationEvent evt )
 	{
 

--- a/src/openccsensors/api/IGaugeSensor.java
+++ b/src/openccsensors/api/IGaugeSensor.java
@@ -3,7 +3,6 @@ package openccsensors.api;
 import java.util.HashMap;
 
 import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
 public interface IGaugeSensor {

--- a/src/openccsensors/api/ISensor.java
+++ b/src/openccsensors/api/ISensor.java
@@ -3,10 +3,8 @@ package openccsensors.api;
 import java.util.HashMap;
 
 import net.minecraft.item.ItemStack;
-import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 
 public interface ISensor {

--- a/src/openccsensors/client/gui/GuiSensor.java
+++ b/src/openccsensors/client/gui/GuiSensor.java
@@ -5,7 +5,6 @@ import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.StatCollector;
-import openccsensors.OpenCCSensors;
 import openccsensors.common.container.ContainerSensor;
 
 import org.lwjgl.opengl.GL11;

--- a/src/openccsensors/client/renderer/tileentity/TileEntityGaugeRenderer.java
+++ b/src/openccsensors/client/renderer/tileentity/TileEntityGaugeRenderer.java
@@ -4,7 +4,6 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import openccsensors.OpenCCSensors;
 import openccsensors.client.model.ModelGauge;
 import openccsensors.common.tileentity.TileEntityGauge;
 

--- a/src/openccsensors/client/renderer/tileentity/TileEntitySensorRenderer.java
+++ b/src/openccsensors/client/renderer/tileentity/TileEntitySensorRenderer.java
@@ -10,11 +10,9 @@ import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ResourceLocation;
-import openccsensors.OpenCCSensors;
 import openccsensors.client.model.ModelSensor;
 import openccsensors.common.item.ItemSensorCard;
 import openccsensors.common.tileentity.TileEntitySensor;
-import openccsensors.common.util.OCSLog;
 
 import org.lwjgl.opengl.GL11;
 

--- a/src/openccsensors/common/CommonProxy.java
+++ b/src/openccsensors/common/CommonProxy.java
@@ -9,8 +9,6 @@ import java.net.URLEncoder;
 
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.ForgeVersion;
-import net.minecraftforge.common.MinecraftForge;
-
 import openccsensors.OpenCCSensors;
 import openccsensors.common.block.BlockBasicSensor;
 import openccsensors.common.block.BlockGauge;

--- a/src/openccsensors/common/GuiHandler.java
+++ b/src/openccsensors/common/GuiHandler.java
@@ -11,25 +11,20 @@ import cpw.mods.fml.common.network.IGuiHandler;
 public class GuiHandler implements IGuiHandler {	
 	
 	@Override
-	public Object getServerGuiElement(int ID, EntityPlayer player,
-			World world, int x, int y, int z) {
+	public Object getServerGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
 		TileEntity tile = world.getBlockTileEntity(x, y, z);
-		if (tile != null) {
+		if (tile != null)
 			return new ContainerSensor(player.inventory, tile);
-		}
 
 		return null;
 	}
 
 	@Override
-	public Object getClientGuiElement(int ID, EntityPlayer player,
-			World world, int x, int y, int z) {
+	public Object getClientGuiElement(int ID, EntityPlayer player, World world, int x, int y, int z) {
 		TileEntity tile = world.getBlockTileEntity(x, y, z);
-		if (tile != null) {
-			if (tile instanceof TileEntitySensor) {
+		if (tile != null)
+			if (tile instanceof TileEntitySensor)
 				return new GuiSensor(player.inventory, tile);
-			}
-		}
 		return null;
 	}
 }

--- a/src/openccsensors/common/block/BlockBasicSensor.java
+++ b/src/openccsensors/common/block/BlockBasicSensor.java
@@ -1,36 +1,26 @@
 package openccsensors.common.block;
 
 import java.util.List;
-import java.util.Map.Entry;
 
-import cpw.mods.fml.common.registry.GameRegistry;
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
-import dan200.computercraft.api.ComputerCraftAPI;
-import openccsensors.OpenCCSensors;
-import openccsensors.api.IBasicSensor;
-import openccsensors.api.SensorCard;
-import openccsensors.common.sensor.ProximitySensor;
-import openccsensors.common.tileentity.TileEntityGauge;
-import openccsensors.common.tileentity.basic.TileEntityBasicProximitySensor;
-import openccsensors.common.util.OCSLog;
-import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.creativetab.CreativeTabs;
-import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Icon;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
-import net.minecraftforge.oredict.ShapedOreRecipe;
+import openccsensors.OpenCCSensors;
+import openccsensors.api.IBasicSensor;
+import openccsensors.common.sensor.ProximitySensor;
+import openccsensors.common.tileentity.basic.TileEntityBasicProximitySensor;
+import cpw.mods.fml.common.registry.GameRegistry;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 
 public class BlockBasicSensor extends BlockContainer {
 

--- a/src/openccsensors/common/block/BlockGauge.java
+++ b/src/openccsensors/common/block/BlockGauge.java
@@ -18,7 +18,6 @@ import openccsensors.common.tileentity.TileEntityGauge;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import dan200.computercraft.api.ComputerCraftAPI;
 
 public class BlockGauge extends BlockContainer {
 

--- a/src/openccsensors/common/block/BlockSensor.java
+++ b/src/openccsensors/common/block/BlockSensor.java
@@ -5,23 +5,19 @@ import java.util.Random;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IconRegister;
-import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Icon;
 import net.minecraft.util.MathHelper;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
 import openccsensors.OpenCCSensors;
 import openccsensors.common.tileentity.TileEntitySensor;
 import openccsensors.common.util.MiscUtils;
-import openccsensors.common.util.OCSLog;
 import cpw.mods.fml.common.registry.GameRegistry;
-import dan200.computercraft.api.ComputerCraftAPI;
 
 public class BlockSensor extends BlockContainer {
 

--- a/src/openccsensors/common/item/ItemGeneric.java
+++ b/src/openccsensors/common/item/ItemGeneric.java
@@ -8,15 +8,12 @@ import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.Icon;
 import openccsensors.OpenCCSensors;
 import openccsensors.api.IItemMeta;
 import openccsensors.api.IRequiresIconLoading;
-import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import dan200.computercraft.api.ComputerCraftAPI;
 
 public class ItemGeneric extends Item {
 

--- a/src/openccsensors/common/item/ItemSensorCard.java
+++ b/src/openccsensors/common/item/ItemSensorCard.java
@@ -24,7 +24,6 @@ import openccsensors.common.SensorTier;
 import openccsensors.common.util.RecipeUtils;
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import dan200.computercraft.api.ComputerCraftAPI;
 
 public class ItemSensorCard extends Item implements ISensorCardRegistry {
 

--- a/src/openccsensors/common/peripheral/PeripheralSensor.java
+++ b/src/openccsensors/common/peripheral/PeripheralSensor.java
@@ -6,9 +6,7 @@ import java.util.Map.Entry;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.Vec3;
 import openccsensors.OpenCCSensors;
 import openccsensors.api.IMethodCallback;
 import openccsensors.api.ISensor;
@@ -17,13 +15,9 @@ import openccsensors.api.ISensorEnvironment;
 import openccsensors.api.SensorCard;
 import openccsensors.common.item.ItemSensorCard;
 import openccsensors.common.util.CallbackEventManager;
-import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.ModContainer;
-import dan200.computercraft.api.ComputerCraftAPI;
+import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
-import dan200.computercraft.api.lua.ILuaContext;
-import dan200.computercraft.api.filesystem.IMount;
 
 public class PeripheralSensor implements IPeripheral, ISensorAccess {
 

--- a/src/openccsensors/common/sensor/CropSensor.java
+++ b/src/openccsensors/common/sensor/CropSensor.java
@@ -11,17 +11,15 @@ import net.minecraft.block.BlockStem;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.src.ModLoader;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
-import net.minecraftforge.common.IPlantable;
 import openccsensors.api.IRequiresIconLoading;
 import openccsensors.api.ISensor;
 import openccsensors.api.ISensorTier;
 import openccsensors.common.util.Ic2Utils;
+import openccsensors.common.util.Mods;
 
 public class CropSensor implements ISensor, IRequiresIconLoading {
 
@@ -87,7 +85,7 @@ public class CropSensor implements ISensor, IRequiresIconLoading {
 			}else if (target.block instanceof BlockPumpkin || target.block instanceof BlockMelon) {
 				response.put("Status", STATUS_GROWN);
 			}
-		}else if (ModLoader.isModLoaded("IC2") && obj instanceof TileEntity) {
+		}else if (Mods.IC2 && obj instanceof TileEntity) {
 			response.putAll(Ic2Utils.getCropDetails(obj, sensorPos, additional));
 		}
 		
@@ -120,7 +118,7 @@ public class CropSensor implements ISensor, IRequiresIconLoading {
 	public ItemStack getUniqueRecipeItem() {
 		return new ItemStack(Item.wheat);
 	}
-
+	
 	@Override
 	public HashMap getTargets(World world, ChunkCoordinates location, ISensorTier tier) {
 
@@ -156,7 +154,7 @@ public class CropSensor implements ISensor, IRequiresIconLoading {
 						targets.put(name, potentialTarget);
 					}else {
 						TileEntity tile = world.getBlockTileEntity(tileX, tileY, tileZ);
-						if (tile != null & ModLoader.isModLoaded("IC2") && Ic2Utils.isValidCropTarget(tile)) {
+						if (Mods.IC2 && Ic2Utils.isValidCropTarget(tile)) {
 							targets.put(name, tile);
 						}
 						

--- a/src/openccsensors/common/sensor/DroppedItemSensor.java
+++ b/src/openccsensors/common/sensor/DroppedItemSensor.java
@@ -8,7 +8,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import openccsensors.api.IRequiresIconLoading;
 import openccsensors.api.ISensor;

--- a/src/openccsensors/common/sensor/InventorySensor.java
+++ b/src/openccsensors/common/sensor/InventorySensor.java
@@ -2,7 +2,6 @@ package openccsensors.common.sensor;
 
 import java.util.HashMap;
 
-import cpw.mods.fml.common.Loader;
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.inventory.IInventory;
@@ -10,7 +9,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import openccsensors.api.IGaugeSensor;
 import openccsensors.api.IRequiresIconLoading;
@@ -18,6 +16,7 @@ import openccsensors.api.ISensor;
 import openccsensors.api.ISensorTier;
 import openccsensors.common.util.AppliedEnergisticsUtils;
 import openccsensors.common.util.InventoryUtils;
+import openccsensors.common.util.Mods;
 
 public class InventorySensor extends TileSensor implements ISensor, IRequiresIconLoading, IGaugeSensor {
 
@@ -28,7 +27,7 @@ public class InventorySensor extends TileSensor implements ISensor, IRequiresIco
 	
 	@Override
 	public boolean isValidTarget(Object target) {
-		return target instanceof IInventory || (Loader.isModLoaded("AppliedEnergistics") && AppliedEnergisticsUtils.isValidTarget(target));
+		return target instanceof IInventory || (Mods.AE && AppliedEnergisticsUtils.isValidTarget(target));
 	}
 	
 	@Override
@@ -38,7 +37,7 @@ public class InventorySensor extends TileSensor implements ISensor, IRequiresIco
 		
 		HashMap response = super.getDetails(tile, sensorPos);
 		
-		if (Loader.isModLoaded("AppliedEnergistics") && AppliedEnergisticsUtils.isValidTarget(obj)) {
+		if (Mods.AE && AppliedEnergisticsUtils.isValidTarget(obj)) {
 			response.putAll(AppliedEnergisticsUtils.getTileDetails(obj, additional));
 		}else {
 			response.putAll(InventoryUtils.getInventorySizeCalculations((IInventory) tile));

--- a/src/openccsensors/common/sensor/MachineSensor.java
+++ b/src/openccsensors/common/sensor/MachineSensor.java
@@ -2,20 +2,19 @@ package openccsensors.common.sensor;
 
 import java.util.HashMap;
 
-import cpw.mods.fml.common.Loader;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import openccsensors.api.IGaugeSensor;
 import openccsensors.api.IRequiresIconLoading;
 import openccsensors.api.ISensor;
 import openccsensors.api.ISensorTier;
 import openccsensors.common.util.Ic2Utils;
+import openccsensors.common.util.Mods;
 import openccsensors.common.util.RotaryCraftUtils;
 import openccsensors.common.util.ThermalExpansionUtils;
 
@@ -35,9 +34,9 @@ public class MachineSensor extends TileSensor implements ISensor, IRequiresIconL
 	
 	@Override
 	public boolean isValidTarget(Object target) {
-		return (Loader.isModLoaded("IC2") && Ic2Utils.isValidMachineTarget(target)) ||
-			   (Loader.isModLoaded("ThermalExpansion") && ThermalExpansionUtils.isValidMachineTarget(target)) ||
-			   (Loader.isModLoaded("RotaryCraft") && RotaryCraftUtils.isValidMachineTarget(target));
+		return (Mods.IC2 && Ic2Utils.isValidMachineTarget(target)) ||
+			   (Mods.TE && ThermalExpansionUtils.isValidMachineTarget(target)) ||
+			   (Mods.RC && RotaryCraftUtils.isValidMachineTarget(target));
 	}
 
 	@Override
@@ -49,15 +48,12 @@ public class MachineSensor extends TileSensor implements ISensor, IRequiresIconL
 	public HashMap getDetails(World world, Object obj, ChunkCoordinates sensorPos, boolean additional) {
 		TileEntity tile = (TileEntity) obj;
 		HashMap response = super.getDetails(tile, sensorPos);
-		if (Loader.isModLoaded("IC2")) {
+		if (Mods.IC2)
 			response.putAll(Ic2Utils.getMachineDetails(world, obj, additional));
-		}
-		if (Loader.isModLoaded("ThermalExpansion")) {
+		if (Mods.TE)
 			response.putAll(ThermalExpansionUtils.getMachineDetails(world, obj, additional));
-		}
-		if (Loader.isModLoaded("RotaryCraft")) {
+		if (Mods.RC)
 			response.putAll(RotaryCraftUtils.getMachineDetails(world, obj, additional));
-		}
 		return response;
 	}
 

--- a/src/openccsensors/common/sensor/MagicSensor.java
+++ b/src/openccsensors/common/sensor/MagicSensor.java
@@ -5,16 +5,15 @@ import java.util.HashMap;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.src.ModLoader;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import openccsensors.api.IRequiresIconLoading;
 import openccsensors.api.ISensor;
 import openccsensors.api.ISensorTier;
 import openccsensors.common.util.MagicUtils;
+import openccsensors.common.util.Mods;
 
 public class MagicSensor extends TileSensor implements ISensor, IRequiresIconLoading {
 
@@ -22,18 +21,18 @@ public class MagicSensor extends TileSensor implements ISensor, IRequiresIconLoa
 
 	@Override
 	public boolean isValidTarget(Object tile) {
-		return (ModLoader.isModLoaded("Thaumcraft") && MagicUtils.isValidAspectTarget(tile)) ||
-		       (ModLoader.isModLoaded("ArsMagica") && MagicUtils.isValidAspectTarget(tile));
+		return (Mods.TC && MagicUtils.isValidAspectTarget(tile)) ||
+		       (Mods.AM && MagicUtils.isValidAspectTarget(tile));
 	}
 
 	@Override
 	public HashMap getDetails(World world, Object obj, ChunkCoordinates sensorPos, boolean additional) {
 		TileEntity tile = (TileEntity) obj;
 		HashMap response = super.getDetails(tile, sensorPos);
-		if (ModLoader.isModLoaded("Thaumcraft")) {
+		if (Mods.TC) {
 			response.put("Aspects", MagicUtils.getMapOfAspects(world, obj, additional));
 		}
-		if (ModLoader.isModLoaded("ArsMagica")) {
+		if (Mods.AM) {
 			response.putAll(MagicUtils.getMapOfArsMagicaPower(world, obj, additional));
 		}
 		return response;

--- a/src/openccsensors/common/sensor/MinecartSensor.java
+++ b/src/openccsensors/common/sensor/MinecartSensor.java
@@ -2,7 +2,6 @@ package openccsensors.common.sensor;
 
 import java.util.HashMap;
 
-import cpw.mods.fml.common.Loader;
 import mods.railcraft.api.carts.IEnergyTransfer;
 import mods.railcraft.api.carts.IExplosiveCart;
 import mods.railcraft.api.carts.IRoutableCart;
@@ -15,7 +14,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.IFluidHandler;
 import openccsensors.api.IRequiresIconLoading;
@@ -23,6 +21,7 @@ import openccsensors.api.ISensor;
 import openccsensors.api.ISensorTier;
 import openccsensors.common.util.EntityUtils;
 import openccsensors.common.util.InventoryUtils;
+import openccsensors.common.util.Mods;
 import openccsensors.common.util.RailcraftUtils;
 import openccsensors.common.util.TankUtils;
 
@@ -59,7 +58,7 @@ public class MinecartSensor implements ISensor, IRequiresIconLoading {
 			response.put("Riding", EntityUtils.livingToMap((EntityLivingBase)minecart.riddenByEntity, sensorPos, true));
 		}
 		
-		if (Loader.isModLoaded("Railcraft")) {
+		if (Mods.RAIL) {
 			if (minecart instanceof IEnergyTransfer) {
 				response.putAll(RailcraftUtils.getEnergyDetails(minecart));
 			}

--- a/src/openccsensors/common/sensor/PowerSensor.java
+++ b/src/openccsensors/common/sensor/PowerSensor.java
@@ -2,14 +2,12 @@ package openccsensors.common.sensor;
 
 import java.util.HashMap;
 
-import cpw.mods.fml.common.Loader;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import openccsensors.api.IGaugeSensor;
 import openccsensors.api.IRequiresIconLoading;
@@ -21,6 +19,7 @@ import openccsensors.common.util.InventoryUtils;
 import openccsensors.common.util.RotaryCraftUtils;
 import openccsensors.common.util.ThermalExpansionUtils;
 import openccsensors.common.util.UniversalElectricityUtils;
+import cpw.mods.fml.common.Loader;
 
 public class PowerSensor extends TileSensor implements ISensor, IRequiresIconLoading, IGaugeSensor {
 

--- a/src/openccsensors/common/sensor/ProximitySensor.java
+++ b/src/openccsensors/common/sensor/ProximitySensor.java
@@ -2,12 +2,9 @@ package openccsensors.common.sensor;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map.Entry;
 
 import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IconRegister;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
@@ -20,7 +17,6 @@ import openccsensors.api.IRequiresIconLoading;
 import openccsensors.api.ISensor;
 import openccsensors.api.ISensorTier;
 import openccsensors.common.util.EntityUtils;
-import openccsensors.common.util.OCSLog;
 
 public class ProximitySensor implements ISensor, IRequiresIconLoading {
 	

--- a/src/openccsensors/common/sensor/SignSensor.java
+++ b/src/openccsensors/common/sensor/SignSensor.java
@@ -2,14 +2,12 @@ package openccsensors.common.sensor;
 
 import java.util.HashMap;
 
-import net.minecraft.block.Block;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntitySign;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import openccsensors.api.IRequiresIconLoading;
 import openccsensors.api.ISensor;

--- a/src/openccsensors/common/sensor/SonicSensor.java
+++ b/src/openccsensors/common/sensor/SonicSensor.java
@@ -7,13 +7,11 @@ import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import openccsensors.api.IRequiresIconLoading;
 import openccsensors.api.ISensor;
 import openccsensors.api.ISensorTier;
-import openccsensors.common.util.OCSLog;
 
 public class SonicSensor implements ISensor, IRequiresIconLoading {
 	

--- a/src/openccsensors/common/sensor/TankSensor.java
+++ b/src/openccsensors/common/sensor/TankSensor.java
@@ -5,24 +5,17 @@ import java.util.HashMap;
 import net.minecraft.client.renderer.texture.IconRegister;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.src.ModLoader;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.Icon;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
-import net.minecraftforge.liquids.ILiquidTank;
-import net.minecraftforge.liquids.ITankContainer;
-import net.minecraftforge.liquids.LiquidStack;
 import openccsensors.api.IRequiresIconLoading;
 import openccsensors.api.ISensor;
 import openccsensors.api.ISensorTier;
-import openccsensors.common.util.InventoryUtils;
 import openccsensors.common.util.TankUtils;
-import openccsensors.common.util.RailcraftUtils;
 
 public class TankSensor extends TileSensor implements ISensor, IRequiresIconLoading {
 	

--- a/src/openccsensors/common/sensor/TileSensor.java
+++ b/src/openccsensors/common/sensor/TileSensor.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import openccsensors.api.ISensorTier;
 import openccsensors.common.util.InventoryUtils;

--- a/src/openccsensors/common/tileentity/TileEntityGauge.java
+++ b/src/openccsensors/common/tileentity/TileEntityGauge.java
@@ -10,17 +10,15 @@ import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.Packet132TileEntityData;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.Vec3;
 import net.minecraftforge.common.ForgeDirection;
 import openccsensors.OpenCCSensors;
 import openccsensors.api.IGaugeSensor;
 import openccsensors.api.IMethodCallback;
 import openccsensors.common.util.CallbackEventManager;
-import openccsensors.common.util.OCSLog;
 import dan200.computercraft.api.ComputerCraftAPI;
-import dan200.computercraft.api.peripheral.IComputerAccess;
-import dan200.computercraft.api.lua.ILuaContext;
 import dan200.computercraft.api.filesystem.IMount;
+import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 
 public class TileEntityGauge extends TileEntity implements IPeripheral {

--- a/src/openccsensors/common/tileentity/TileEntitySensor.java
+++ b/src/openccsensors/common/tileentity/TileEntitySensor.java
@@ -10,12 +10,11 @@ import net.minecraft.network.packet.Packet;
 import net.minecraft.network.packet.Packet132TileEntityData;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import openccsensors.api.ISensorEnvironment;
 import openccsensors.common.peripheral.PeripheralSensor;
-import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.lua.ILuaContext;
+import dan200.computercraft.api.peripheral.IComputerAccess;
 import dan200.computercraft.api.peripheral.IPeripheral;
 
 public class TileEntitySensor extends TileEntity implements ISensorEnvironment,

--- a/src/openccsensors/common/tileentity/basic/TileEntityBasicProximitySensor.java
+++ b/src/openccsensors/common/tileentity/basic/TileEntityBasicProximitySensor.java
@@ -1,9 +1,5 @@
 package openccsensors.common.tileentity.basic;
 
-import openccsensors.OpenCCSensors;
-import openccsensors.api.IBasicSensor;
-import openccsensors.common.sensor.ProximitySensor;
-import openccsensors.common.util.OCSLog;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.INetworkManager;
@@ -13,7 +9,9 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChatMessageComponent;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.Vec3;
-import net.minecraft.world.World;
+import openccsensors.OpenCCSensors;
+import openccsensors.api.IBasicSensor;
+import openccsensors.common.sensor.ProximitySensor;
 
 public class TileEntityBasicProximitySensor extends TileEntity implements IBasicSensor {
 

--- a/src/openccsensors/common/turtle/TurtleSensorEnvironment.java
+++ b/src/openccsensors/common/turtle/TurtleSensorEnvironment.java
@@ -3,7 +3,6 @@ package openccsensors.common.turtle;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
 import openccsensors.api.ISensorEnvironment;
 import dan200.computercraft.api.turtle.ITurtleAccess;

--- a/src/openccsensors/common/turtle/TurtleUpgradeSensor.java
+++ b/src/openccsensors/common/turtle/TurtleUpgradeSensor.java
@@ -17,7 +17,6 @@ import dan200.computercraft.api.turtle.TurtleSide;
 import dan200.computercraft.api.turtle.TurtleUpgradeType;
 import dan200.computercraft.api.turtle.TurtleVerb;
 
-
 public class TurtleUpgradeSensor implements ITurtleUpgrade {
 
 	public TurtleUpgradeSensor() {

--- a/src/openccsensors/common/util/AppliedEnergisticsUtils.java
+++ b/src/openccsensors/common/util/AppliedEnergisticsUtils.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import appeng.api.me.tiles.IGridMachine;
 import appeng.api.me.tiles.IGridTileEntity;
 import appeng.api.me.util.IGridInterface;
 import appeng.api.me.util.IMEInventory;

--- a/src/openccsensors/common/util/BuildcraftUtils.java
+++ b/src/openccsensors/common/util/BuildcraftUtils.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import net.minecraft.world.World;
 import net.minecraftforge.common.ForgeDirection;
 import buildcraft.api.power.IPowerReceptor;
-import buildcraft.api.power.PowerHandler;
 import buildcraft.api.power.PowerHandler.PowerReceiver;
 
 public class BuildcraftUtils {

--- a/src/openccsensors/common/util/EntityUtils.java
+++ b/src/openccsensors/common/util/EntityUtils.java
@@ -4,9 +4,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 
-import net.minecraft.block.Block;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.EntityLiving;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.passive.EntityTameable;
 import net.minecraft.entity.passive.EntityWolf;

--- a/src/openccsensors/common/util/ForestryUtils.java
+++ b/src/openccsensors/common/util/ForestryUtils.java
@@ -2,8 +2,7 @@ package openccsensors.common.util;
 
 import java.util.HashMap;
 
-import forestry.api.apiculture.BeeManager;
-import forestry.api.apiculture.IAlleleBeeSpecies;
+import net.minecraft.item.ItemStack;
 import forestry.api.apiculture.IBee;
 import forestry.api.apiculture.IBeeGenome;
 import forestry.api.arboriculture.ITree;
@@ -22,8 +21,6 @@ import forestry.api.genetics.IIndividual;
 import forestry.api.genetics.ISpeciesRoot;
 import forestry.api.lepidopterology.IButterfly;
 import forestry.api.lepidopterology.IButterflyGenome;
-
-import net.minecraft.item.ItemStack;
 
 public class ForestryUtils {
 	

--- a/src/openccsensors/common/util/Ic2Utils.java
+++ b/src/openccsensors/common/util/Ic2Utils.java
@@ -1,9 +1,5 @@
 package openccsensors.common.util;
 
-import ic2.api.reactor.IC2Reactor;
-import ic2.api.reactor.IReactor;
-import ic2.api.reactor.IReactorChamber;
-import ic2.api.tile.IEnergyStorage;
 import ic2.api.crops.CropCard;
 import ic2.api.crops.Crops;
 import ic2.api.crops.ICropTile;
@@ -11,17 +7,20 @@ import ic2.api.energy.EnergyNet;
 import ic2.api.energy.tile.IEnergyConductor;
 import ic2.api.energy.tile.IEnergySink;
 import ic2.api.energy.tile.IEnergySource;
+import ic2.api.reactor.IC2Reactor;
+import ic2.api.reactor.IReactor;
+import ic2.api.reactor.IReactorChamber;
+import ic2.api.tile.IEnergyStorage;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import openccsensors.common.sensor.CropSensor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.ChunkCoordinates;
-import net.minecraft.util.Vec3;
 import net.minecraft.world.World;
+import openccsensors.common.sensor.CropSensor;
 
 public class Ic2Utils {
 

--- a/src/openccsensors/common/util/MagicUtils.java
+++ b/src/openccsensors/common/util/MagicUtils.java
@@ -1,15 +1,13 @@
 package openccsensors.common.util;
 
 import java.util.HashMap;
-import java.util.Map;
 
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.World;
-
-import am2.api.power.IPowerIntegration;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.aspects.IAspectContainer;
+import am2.api.power.IPowerIntegration;
 
 public class MagicUtils {
 

--- a/src/openccsensors/common/util/MiscUtils.java
+++ b/src/openccsensors/common/util/MiscUtils.java
@@ -7,9 +7,6 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.MathHelper;
-import net.minecraft.util.Vec3;
-import net.minecraftforge.common.ForgeDirection;
 
 public class MiscUtils {
 

--- a/src/openccsensors/common/util/Mods.java
+++ b/src/openccsensors/common/util/Mods.java
@@ -1,0 +1,42 @@
+package openccsensors.common.util;
+
+import cpw.mods.fml.common.Loader;
+
+public class Mods {
+	
+	/***
+	 * IndustrialCraft 2
+	 */
+	public static final boolean IC2 = Loader.isModLoaded("IC2");
+	
+	/***
+	 * Applied Energistics
+	 */
+	public static final boolean AE = Loader.isModLoaded("AppliedEnergistics");
+	
+	/***
+	 * Thermal Expansion
+	 */
+	public static final boolean TE = Loader.isModLoaded("ThermalExpansion");
+	
+	/***
+	 * RotaryCraft
+	 */
+	public static final boolean RC = Loader.isModLoaded("RotaryCraft");
+	
+	/***
+	 * ThaumCraft
+	 */
+	public static final boolean TC = Loader.isModLoaded("ThaumCraft");
+	
+	/***
+	 * Ars Magica
+	 */
+	public static final boolean AM = Loader.isModLoaded("ArsMagica");
+	
+	/***
+	 * RailCraft
+	 */
+	public static final boolean RAIL = Loader.isModLoaded("Railcraft");
+	
+}

--- a/src/openccsensors/common/util/RailcraftUtils.java
+++ b/src/openccsensors/common/util/RailcraftUtils.java
@@ -1,17 +1,10 @@
 package openccsensors.common.util;
 
-import ic2.api.tile.IEnergyStorage;
-
 import java.util.HashMap;
 
-import buildcraft.api.power.IPowerReceptor;
-import buildcraft.api.power.PowerHandler.PowerReceiver;
 import mods.railcraft.api.carts.IEnergyTransfer;
 import mods.railcraft.api.carts.IExplosiveCart;
 import net.minecraft.entity.item.EntityMinecart;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.world.World;
-import net.minecraftforge.common.ForgeDirection;
 
 
 public class RailcraftUtils {

--- a/src/openccsensors/common/util/TankUtils.java
+++ b/src/openccsensors/common/util/TankUtils.java
@@ -2,19 +2,12 @@ package openccsensors.common.util;
 
 import java.util.HashMap;
 
-import net.minecraft.item.ItemStack;
 import net.minecraftforge.common.ForgeDirection;
 import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidRegistry;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidTankInfo;
 import net.minecraftforge.fluids.IFluidHandler;
-import net.minecraftforge.fluids.IFluidTank;
-import net.minecraftforge.liquids.ILiquidTank;
-import net.minecraftforge.liquids.ITankContainer;
-import net.minecraftforge.liquids.LiquidStack;
-
-import openccsensors.common.util.InventoryUtils;
 
 public class TankUtils {
 


### PR DESCRIPTION
This is just basic Java fixing, since I havent developed / dont know the code of OpenCCSensors. 
Should help you get it up and running faster for updating to 1.63. And by the way, you need an IPeripheralHandler for CC to detect peripherals, it doesnt do that automatically anymore.
