### PR TITLE
reduce range on sonic sensor, closes #171

### DIFF
--- a/src/openccsensors/common/sensor/SonicSensor.java
+++ b/src/openccsensors/common/sensor/SonicSensor.java
@@ -18,7 +18,7 @@ import openccsensors.common.util.OCSLog;
 public class SonicSensor implements ISensor, IRequiresIconLoading {
 	
 	private Icon icon;
-	private static final int BASE_RANGE = 3;
+	private static final int BASE_RANGE = 1;
 	
 	@Override
 	public HashMap getDetails(World world, Object obj, ChunkCoordinates sensorPos, boolean additional) {


### PR DESCRIPTION
This gets the range on the sonic sensor closer to where it should be, though it still is larger than the documented range.  I think it's best to just stick with this at this point and update the documentation to match.
