### PR TITLE
Fix crash when placing a gauge on a Buildcraft Tank.

### DIFF
--- a/src/main/java/openccsensors/common/tileentity/TileEntityGauge.java
+++ b/src/main/java/openccsensors/common/tileentity/TileEntityGauge.java
@@ -173,7 +173,7 @@ public class TileEntityGauge extends TileEntity implements IPeripheral {
 						updatePropertyName = entry.getKey();
 					}
 				}
-				percentage = ((Double) (tileProperties.get(updatePropertyName))).intValue();
+				percentage = ((Number) (tileProperties.get(updatePropertyName))).intValue();
 			}
 			if (lastBroadcast++ % 10 == 0) {
 				lastBroadcast = 1;


### PR DESCRIPTION
Placing a gauge on a Buildcraft tank would crash the game due to incompatible types. This change prevents the crash, though the gauge does not display the correct value.